### PR TITLE
Fix default setVersion value corresponding to checked element

### DIFF
--- a/src/assets/js/welcome.js
+++ b/src/assets/js/welcome.js
@@ -44,4 +44,4 @@ function startAdventure() {
   restartTime();
 }
 
-setVersion('15');
+setVersion('60');


### PR DESCRIPTION
Hello,
In [index.html](https://github.com/Orange-OpenSource/Tota11ylost/blob/main/src/index.html#L88) we have the 60min version checked by default but the `welcome.js` file define the version to 15 by default.

If we don't click on any radio, we will launch the 15 min version whereas the 60min radio is checked.

We could also do the opposite and change the checked radio in index.html to the 15 min one.