### PR TITLE
Totally lost v2 se fix hints

### DIFF
--- a/app/components/GameHints.vue
+++ b/app/components/GameHints.vue
@@ -38,6 +38,7 @@ const hints = useHints({
           type="button"
           class="btn fs-3 p-2 btn-primary"
           :disabled="hints.noMoreHints.value"
+          :aria-label="hints.noMoreHints.value ? $t('hints.noMoreHints') : hints.hintButtonA11yLabel.value"
           @click="hints.takeHint()"
         >
           {{ hints.noMoreHints.value ? $t('hints.noMoreHints') : hints.hintButtonLabel.value }}

--- a/app/components/GameTimer.vue
+++ b/app/components/GameTimer.vue
@@ -5,7 +5,21 @@ defineProps<{
   isFinal?: boolean
 }>()
 
+const { t } = useI18n()
 const timer = useGameTimer()
+
+// Builds "X minutes Y secondes" for screen readers — the visual digits use aria-hidden
+const accessibleTime = computed(() => {
+  const d = timer.digits.value
+  const hours = d[0] ?? 0
+  const minutes = ((d[1] ?? 0) * 10) + (d[2] ?? 0)
+  const seconds = ((d[3] ?? 0) * 10) + (d[4] ?? 0)
+  const parts: string[] = []
+  if (hours > 0) parts.push(`${hours} ${t('common.time.hour.full', hours)}`)
+  parts.push(`${minutes} ${t('common.time.minute.full', minutes)}`)
+  parts.push(`${seconds} ${t('common.time.second.full', seconds)}`)
+  return parts.join(' ')
+})
 </script>
 
 <template>
@@ -45,7 +59,7 @@ const timer = useGameTimer()
 
     <!-- Screen reader accessible version -->
     <p class="visually-hidden" role="status">
-      {{ timer.displayTime.value }}
+      {{ accessibleTime }}
     </p>
   </div>
 </template>

--- a/app/composables/useHints.ts
+++ b/app/composables/useHints.ts
@@ -42,12 +42,25 @@ export function useHints(options: HintOptions) {
   function getHintButtonLabel(): string {
     const time = penaltyTimes[currentHintIndex.value]
     if (!time) return t('hints.noMoreHints')
-    const unit = time < 60 ? 'sec' : 'min'
     const duration = time < 60 ? time : time / 60
+    const unit = time < 60
+      ? t('common.time.second.abbr', duration)
+      : t('common.time.minute.abbr', duration)
+    return t('form.labelHintsButton', { duration, unit })
+  }
+
+  function getHintButtonA11yLabel(): string {
+    const time = penaltyTimes[currentHintIndex.value]
+    if (!time) return t('hints.noMoreHints')
+    const duration = time < 60 ? time : time / 60
+    const unit = time < 60
+      ? t('common.time.second.full', duration)
+      : t('common.time.minute.full', duration)
     return t('form.labelHintsButton', { duration, unit })
   }
 
   const hintButtonLabel = computed(() => getHintButtonLabel())
+  const hintButtonA11yLabel = computed(() => getHintButtonA11yLabel())
 
   function takeHint() {
     if (noMoreHints.value || currentHintIndex.value >= 3) return
@@ -100,6 +113,7 @@ export function useHints(options: HintOptions) {
     noMoreHints,
     hintTexts,
     hintButtonLabel,
+    hintButtonA11yLabel,
     takeHint,
   }
 }

--- a/app/composables/useHints.ts
+++ b/app/composables/useHints.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) Orange SA
 
+import type { VueMessageType } from 'vue-i18n'
+
 export interface HintOptions {
   pageId: string
   isFormRegistration?: boolean
@@ -11,7 +13,7 @@ export interface HintOptions {
 }
 
 export function useHints(options: HintOptions) {
-  const { t } = useI18n()
+  const { t, tm, rt } = useI18n()
   const route = useRoute()
   const timer = useGameTimer()
 
@@ -69,10 +71,11 @@ export function useHints(options: HintOptions) {
     timer.addPenalty(penaltyTimes[idx] as number)
     currentHintIndex.value++
 
-    // Get hint text from i18n
-    const hintsArray = t(`hints.${options.pageId}`, { returnObjects: true })
-    if (Array.isArray(hintsArray) && hintsArray[currentHintIndex.value - 1]) {
-      hintTexts.value.push(hintsArray[currentHintIndex.value - 1] as string)
+    // Get hint text from i18n — tm() returns the raw message array, rt() resolves each item to a string
+    const hintsArray = tm(`hints.${options.pageId}`) as unknown as VueMessageType[]
+    const rawHint = hintsArray[currentHintIndex.value - 1]
+    if (Array.isArray(hintsArray) && rawHint) {
+      hintTexts.value.push(rt(rawHint))
     }
 
     // Call the page-specific hint callback

--- a/app/pages/scores.vue
+++ b/app/pages/scores.vue
@@ -5,6 +5,7 @@ definePageMeta({ layout: 'default', title: 'scores.tabTitle' })
 
 const route = useRoute()
 const gameStore = useGameStore()
+const { t } = useI18n()
 const { storeScore, getGeneralScores, getTodayScores } = useFirebaseScores()
 
 interface ScoreEntry {
@@ -17,16 +18,29 @@ const generalScores = ref<ScoreEntry[]>([])
 const pseudo = computed(() => gameStore.pseudo)
 const version = computed(() => gameStore.version)
 
-// Format time from ms to displayable string
+// Visual format: "05min 30s" — aria-hidden, abbreviations from i18n (with EN plurals)
 function formatTime(ms: number): string {
   const totalSec = Math.floor(ms / 1000)
   const h = Math.floor(totalSec / 3600)
   const m = Math.floor((totalSec % 3600) / 60)
   const s = totalSec % 60
   const parts: string[] = []
-  if (h > 0) parts.push(`${h}h`)
-  parts.push(`${String(m).padStart(2, '0')}min`)
-  parts.push(`${String(s).padStart(2, '0')}s`)
+  if (h > 0) parts.push(`${h}${t('common.time.hour.abbr', h)}`)
+  parts.push(`${String(m).padStart(2, '0')}${t('common.time.minute.abbr', m)}`)
+  parts.push(`${String(s).padStart(2, '0')}${t('common.time.second.abbr', s)}`)
+  return parts.join(' ')
+}
+
+// Accessible format: "5 minutes 30 secondes" — visually hidden, for screen readers
+function formatTimeA11y(ms: number): string {
+  const totalSec = Math.floor(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  const parts: string[] = []
+  if (h > 0) parts.push(`${h} ${t('common.time.hour.full', h)}`)
+  parts.push(`${m} ${t('common.time.minute.full', m)}`)
+  parts.push(`${s} ${t('common.time.second.full', s)}`)
   return parts.join(' ')
 }
 
@@ -88,7 +102,8 @@ onMounted(loadScores)
               {{ $t('scores.finalTime') }}
             </p>
             <div class="d-flex align-items-center fs-3 fw-bold">
-              {{ finalTimeDisplay }}
+              <span aria-hidden="true">{{ finalTimeDisplay }}</span>
+              <span class="visually-hidden">{{ formatTimeA11y(finalElapsed) }}</span>
             </div>
             <p class="fw-bold mt-3 fs-4" v-html="$t('scores.toKnowMore')" />
           </div>
@@ -128,7 +143,8 @@ onMounted(loadScores)
                         {{ entry.pseudo }}
                       </p>
                       <p class="mb-0 fs-6" :class="isCurrent(entry) ? 'text-white' : 'text-body-secondary'">
-                        {{ formatTime(entry.timer) }}
+                        <span aria-hidden="true">{{ formatTime(entry.timer) }}</span>
+                        <span class="visually-hidden">{{ formatTimeA11y(entry.timer) }}</span>
                       </p>
                     </td>
                     <td class="py-7 vertical-align" aria-hidden="true">
@@ -166,7 +182,8 @@ onMounted(loadScores)
                         {{ entry.pseudo }}
                       </p>
                       <p class="mb-0 fs-6" :class="isCurrent(entry) ? 'text-white' : 'text-body-secondary'">
-                        {{ formatTime(entry.timer) }}
+                        <span aria-hidden="true">{{ formatTime(entry.timer) }}</span>
+                        <span class="visually-hidden">{{ formatTimeA11y(entry.timer) }}</span>
                       </p>
                     </td>
                     <td class="py-7 vertical-align" aria-hidden="true">

--- a/i18n/lang/en.json
+++ b/i18n/lang/en.json
@@ -25,6 +25,20 @@
       "title": "Timer",
       "aria-label_timerArea": "Timer area of the escape game"
     },
+    "time": {
+      "hour": {
+        "abbr": "h",
+        "full": "hour | hours"
+      },
+      "minute": {
+        "abbr": "min | mins",
+        "full": "minute | minutes"
+      },
+      "second": {
+        "abbr": "sec | secs",
+        "full": "second | seconds"
+      }
+    },
     "footer": {
       "sitemapAndInformation": "Sitemap & information",
       "copyright": "© Orange 2026",

--- a/i18n/lang/es.json
+++ b/i18n/lang/es.json
@@ -25,6 +25,20 @@
       "title": "Cronómetro",
       "aria-label_timerArea": "Área del temporizador del juego de escape"
     },
+    "time": {
+      "hour": {
+        "abbr": "h",
+        "full": "hora | horas"
+      },
+      "minute": {
+        "abbr": "min",
+        "full": "minuto | minutos"
+      },
+      "second": {
+        "abbr": "s",
+        "full": "segundo | segundos"
+      }
+    },
     "footer": {
       "sitemapAndInformation": "Mapa web",
       "copyright": "© Orange 2026",

--- a/i18n/lang/fr.json
+++ b/i18n/lang/fr.json
@@ -25,6 +25,20 @@
       "title": "Chronomètre",
       "aria-label_timerArea": "Zone du chronomètre de l'<span lang='en'>Escape game</span>"
     },
+    "time": {
+      "hour": {
+        "abbr": "h",
+        "full": "heure | heures"
+      },
+      "minute": {
+        "abbr": "min",
+        "full": "minute | minutes"
+      },
+      "second": {
+        "abbr": "s",
+        "full": "seconde | secondes"
+      }
+    },
     "footer": {
       "sitemapAndInformation": "Plan du site & informations",
       "copyright": "© Orange 2026",


### PR DESCRIPTION
Hints were not displayed to the screen when "show hints" botton was triggered except the level's solution. This was due to the t() function from i18n which returned only one string instead of à table registered in the lang.json files.