### PR TITLE
Totally lost v2 se fix @ and table management wording

### DIFF
--- a/app/components/GameHints.vue
+++ b/app/components/GameHints.vue
@@ -38,6 +38,7 @@ const hints = useHints({
           type="button"
           class="btn fs-3 p-2 btn-primary"
           :disabled="hints.noMoreHints.value"
+          :aria-label="hints.noMoreHints.value ? $t('hints.noMoreHints') : hints.hintButtonA11yLabel.value"
           @click="hints.takeHint()"
         >
           {{ hints.noMoreHints.value ? $t('hints.noMoreHints') : hints.hintButtonLabel.value }}

--- a/app/components/GameTimer.vue
+++ b/app/components/GameTimer.vue
@@ -5,7 +5,21 @@ defineProps<{
   isFinal?: boolean
 }>()
 
+const { t } = useI18n()
 const timer = useGameTimer()
+
+// Builds "X minutes Y secondes" for screen readers — the visual digits use aria-hidden
+const accessibleTime = computed(() => {
+  const d = timer.digits.value
+  const hours = d[0] ?? 0
+  const minutes = ((d[1] ?? 0) * 10) + (d[2] ?? 0)
+  const seconds = ((d[3] ?? 0) * 10) + (d[4] ?? 0)
+  const parts: string[] = []
+  if (hours > 0) parts.push(`${hours} ${t('common.time.hour.full', hours)}`)
+  parts.push(`${minutes} ${t('common.time.minute.full', minutes)}`)
+  parts.push(`${seconds} ${t('common.time.second.full', seconds)}`)
+  return parts.join(' ')
+})
 </script>
 
 <template>
@@ -45,7 +59,7 @@ const timer = useGameTimer()
 
     <!-- Screen reader accessible version -->
     <p class="visually-hidden" role="status">
-      {{ timer.displayTime.value }}
+      {{ accessibleTime }}
     </p>
   </div>
 </template>

--- a/app/composables/useHints.ts
+++ b/app/composables/useHints.ts
@@ -42,12 +42,25 @@ export function useHints(options: HintOptions) {
   function getHintButtonLabel(): string {
     const time = penaltyTimes[currentHintIndex.value]
     if (!time) return t('hints.noMoreHints')
-    const unit = time < 60 ? 'sec' : 'min'
     const duration = time < 60 ? time : time / 60
+    const unit = time < 60
+      ? t('common.time.second.abbr', duration)
+      : t('common.time.minute.abbr', duration)
+    return t('form.labelHintsButton', { duration, unit })
+  }
+
+  function getHintButtonA11yLabel(): string {
+    const time = penaltyTimes[currentHintIndex.value]
+    if (!time) return t('hints.noMoreHints')
+    const duration = time < 60 ? time : time / 60
+    const unit = time < 60
+      ? t('common.time.second.full', duration)
+      : t('common.time.minute.full', duration)
     return t('form.labelHintsButton', { duration, unit })
   }
 
   const hintButtonLabel = computed(() => getHintButtonLabel())
+  const hintButtonA11yLabel = computed(() => getHintButtonA11yLabel())
 
   function takeHint() {
     if (noMoreHints.value || currentHintIndex.value >= 3) return
@@ -100,6 +113,7 @@ export function useHints(options: HintOptions) {
     noMoreHints,
     hintTexts,
     hintButtonLabel,
+    hintButtonA11yLabel,
     takeHint,
   }
 }

--- a/app/composables/useHints.ts
+++ b/app/composables/useHints.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) Orange SA
 
+import type { VueMessageType } from 'vue-i18n'
+
 export interface HintOptions {
   pageId: string
   isFormRegistration?: boolean
@@ -11,7 +13,7 @@ export interface HintOptions {
 }
 
 export function useHints(options: HintOptions) {
-  const { t } = useI18n()
+  const { t, tm, rt } = useI18n()
   const route = useRoute()
   const timer = useGameTimer()
 
@@ -69,10 +71,11 @@ export function useHints(options: HintOptions) {
     timer.addPenalty(penaltyTimes[idx] as number)
     currentHintIndex.value++
 
-    // Get hint text from i18n
-    const hintsArray = t(`hints.${options.pageId}`, { returnObjects: true })
-    if (Array.isArray(hintsArray) && hintsArray[currentHintIndex.value - 1]) {
-      hintTexts.value.push(hintsArray[currentHintIndex.value - 1] as string)
+    // Get hint text from i18n — tm() returns the raw message array, rt() resolves each item to a string
+    const hintsArray = tm(`hints.${options.pageId}`) as unknown as VueMessageType[]
+    const rawHint = hintsArray[currentHintIndex.value - 1]
+    if (Array.isArray(hintsArray) && rawHint) {
+      hintTexts.value.push(rt(rawHint))
     }
 
     // Call the page-specific hint callback

--- a/app/pages/hearing-simulation.vue
+++ b/app/pages/hearing-simulation.vue
@@ -3,7 +3,7 @@
 <script setup lang="ts">
 definePageMeta({ layout: 'without-footer', title: 'hearingSimu.tabTitle' })
 
-const { t, locale, messages } = useI18n()
+const { t, te } = useI18n()
 const router = useRouter()
 const gameStore = useGameStore()
 
@@ -11,27 +11,10 @@ const answer = ref('')
 const showError = ref(false)
 
 const possibleResponses = computed(() => {
-  // Force reactivity on locale change
-  void locale.value
-
   const responses: string[] = []
-  const currentMessages = messages.value[locale.value]
-
-  for (let i = 0; i < 5; i++) {
-    // Check if the key exists in the current language
-    const keyPath = `hearingSimu.possibleResponses.${i}`
-    const nested = keyPath.split('.').reduce((obj: unknown, key: string) => {
-      return typeof obj === 'object' && obj !== null ? (obj as Record<string, unknown>)[key] : undefined
-    }, currentMessages)
-
-    if (nested === undefined) {
-      break
-    }
-
-    const resp = t(keyPath)
-    responses.push(resp)
+  for (let i = 0; te(`hearingSimu.possibleResponses.${i}`); i++) {
+    responses.push(t(`hearingSimu.possibleResponses.${i}`).toLowerCase())
   }
-  console.log('Possible responses:', responses)
   return responses
 })
 

--- a/app/pages/hearing.vue
+++ b/app/pages/hearing.vue
@@ -3,7 +3,7 @@
 <script setup lang="ts">
 definePageMeta({ layout: 'without-footer', title: 'hearing.tabTitle' })
 
-const { t, locale } = useI18n()
+const { t, locale, te } = useI18n()
 const router = useRouter()
 
 const answer = ref('')
@@ -35,17 +35,12 @@ function onSeeking(event: Event) {
 function validate() {
   const userAnswer = answer.value.toLowerCase()
 
-  // Collect responses until we can't find more (max 2)
   const responses: string[] = []
-  for (let i = 0; i < 2; i++) {
-    const resp = t(`hearing.possibleResponses.${i}`)
-    if (resp === `hearing.possibleResponses.${i}`) {
-      break
-    }
-    responses.push(resp)
+  for (let i = 0; te(`hearing.possibleResponses.${i}`); i++) {
+    responses.push(t(`hearing.possibleResponses.${i}`).toLowerCase())
   }
 
-  if (responses.some(resp => userAnswer.includes(resp.toLowerCase()))) {
+  if (responses.some(resp => userAnswer.includes(resp))) {
     router.push('/hearing-simulation')
   }
   else {

--- a/app/pages/scores.vue
+++ b/app/pages/scores.vue
@@ -5,6 +5,7 @@ definePageMeta({ layout: 'default', title: 'scores.tabTitle' })
 
 const route = useRoute()
 const gameStore = useGameStore()
+const { t } = useI18n()
 const { storeScore, getGeneralScores, getTodayScores } = useFirebaseScores()
 
 interface ScoreEntry {
@@ -17,16 +18,29 @@ const generalScores = ref<ScoreEntry[]>([])
 const pseudo = computed(() => gameStore.pseudo)
 const version = computed(() => gameStore.version)
 
-// Format time from ms to displayable string
+// Visual format: "05min 30s" — aria-hidden, abbreviations from i18n (with EN plurals)
 function formatTime(ms: number): string {
   const totalSec = Math.floor(ms / 1000)
   const h = Math.floor(totalSec / 3600)
   const m = Math.floor((totalSec % 3600) / 60)
   const s = totalSec % 60
   const parts: string[] = []
-  if (h > 0) parts.push(`${h}h`)
-  parts.push(`${String(m).padStart(2, '0')}min`)
-  parts.push(`${String(s).padStart(2, '0')}s`)
+  if (h > 0) parts.push(`${h}${t('common.time.hour.abbr', h)}`)
+  parts.push(`${String(m).padStart(2, '0')}${t('common.time.minute.abbr', m)}`)
+  parts.push(`${String(s).padStart(2, '0')}${t('common.time.second.abbr', s)}`)
+  return parts.join(' ')
+}
+
+// Accessible format: "5 minutes 30 secondes" — visually hidden, for screen readers
+function formatTimeA11y(ms: number): string {
+  const totalSec = Math.floor(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  const parts: string[] = []
+  if (h > 0) parts.push(`${h} ${t('common.time.hour.full', h)}`)
+  parts.push(`${m} ${t('common.time.minute.full', m)}`)
+  parts.push(`${s} ${t('common.time.second.full', s)}`)
   return parts.join(' ')
 }
 
@@ -88,7 +102,8 @@ onMounted(loadScores)
               {{ $t('scores.finalTime') }}
             </p>
             <div class="d-flex align-items-center fs-3 fw-bold">
-              {{ finalTimeDisplay }}
+              <span aria-hidden="true">{{ finalTimeDisplay }}</span>
+              <span class="visually-hidden">{{ formatTimeA11y(finalElapsed) }}</span>
             </div>
             <p class="fw-bold mt-3 fs-4" v-html="$t('scores.toKnowMore')" />
           </div>
@@ -128,7 +143,8 @@ onMounted(loadScores)
                         {{ entry.pseudo }}
                       </p>
                       <p class="mb-0 fs-6" :class="isCurrent(entry) ? 'text-white' : 'text-body-secondary'">
-                        {{ formatTime(entry.timer) }}
+                        <span aria-hidden="true">{{ formatTime(entry.timer) }}</span>
+                        <span class="visually-hidden">{{ formatTimeA11y(entry.timer) }}</span>
                       </p>
                     </td>
                     <td class="py-7 vertical-align" aria-hidden="true">
@@ -166,7 +182,8 @@ onMounted(loadScores)
                         {{ entry.pseudo }}
                       </p>
                       <p class="mb-0 fs-6" :class="isCurrent(entry) ? 'text-white' : 'text-body-secondary'">
-                        {{ formatTime(entry.timer) }}
+                        <span aria-hidden="true">{{ formatTime(entry.timer) }}</span>
+                        <span class="visually-hidden">{{ formatTimeA11y(entry.timer) }}</span>
                       </p>
                     </td>
                     <td class="py-7 vertical-align" aria-hidden="true">

--- a/i18n/lang/en.json
+++ b/i18n/lang/en.json
@@ -25,6 +25,20 @@
       "title": "Timer",
       "aria-label_timerArea": "Timer area of the escape game"
     },
+    "time": {
+      "hour": {
+        "abbr": "h",
+        "full": "hour | hours"
+      },
+      "minute": {
+        "abbr": "min | mins",
+        "full": "minute | minutes"
+      },
+      "second": {
+        "abbr": "sec | secs",
+        "full": "second | seconds"
+      }
+    },
     "footer": {
       "sitemapAndInformation": "Sitemap & information",
       "copyright": "© Orange 2026",

--- a/i18n/lang/en.json
+++ b/i18n/lang/en.json
@@ -345,10 +345,10 @@
     "errorFirstName": "The first name is required",
     "errorPassword": "The password must be between 4 and 8 characters",
     "errorAge": "The age must be a number less than 18",
-    "errorEmail": "The email format is not valid. Example format: lastname.firstnameAROBASEorange.com",
+    "errorEmail": "The email format is not valid. Example format: lastname.firstname{'@'}orange.com",
     "errorPhoneNumber": "The phone number format is not valid. Example format: +33612345678",
     "errorFruits": "Only 3 fruits must be selected!!!",
-    "detailEmail": "(format: lastname.firstnameAROBASEdomain.com)",
+    "detailEmail": "(format: lastname.firstname{'@'}domain.com)",
     "detailPhoneNumber": "(format: +33 followed by 9 digits)",
     "detailFruits": "(3 fruits)"
   },

--- a/i18n/lang/es.json
+++ b/i18n/lang/es.json
@@ -25,6 +25,20 @@
       "title": "Cronómetro",
       "aria-label_timerArea": "Área del temporizador del juego de escape"
     },
+    "time": {
+      "hour": {
+        "abbr": "h",
+        "full": "hora | horas"
+      },
+      "minute": {
+        "abbr": "min",
+        "full": "minuto | minutos"
+      },
+      "second": {
+        "abbr": "s",
+        "full": "segundo | segundos"
+      }
+    },
     "footer": {
       "sitemapAndInformation": "Mapa web",
       "copyright": "© Orange 2026",

--- a/i18n/lang/es.json
+++ b/i18n/lang/es.json
@@ -347,10 +347,10 @@
     "errorFirstName": "El nombre es obligatorio",
     "errorPassword": "La contraseña debe tener entre 4 y 8 caracteres",
     "errorAge": "La edad debe ser un número menor a 18",
-    "errorEmail": "El formato del correo electrónico no es válido. Ejemplo de formato: nombreapellidoAROBASEorange.com",
+    "errorEmail": "El formato del correo electrónico no es válido. Ejemplo de formato: nombreapellido{'@'}orange.com",
     "errorPhoneNumber": "El formato del teléfono no es válido. Ejemplo de formato: +34612345678",
     "errorFruits": "¡Solo se deben seleccionar 3 frutas!",
-    "detailEmail": "(formato: nombreapellidoAROBASEdomain.com)",
+    "detailEmail": "(formato: nombreapellido{'@'}domain.com)",
     "detailPhoneNumber": "(formato: +34 seguido de 9 dígitos)",
     "detailFruits": "(3 frutas)"
   },

--- a/i18n/lang/fr.json
+++ b/i18n/lang/fr.json
@@ -25,6 +25,20 @@
       "title": "Chronomètre",
       "aria-label_timerArea": "Zone du chronomètre de l'<span lang='en'>Escape game</span>"
     },
+    "time": {
+      "hour": {
+        "abbr": "h",
+        "full": "heure | heures"
+      },
+      "minute": {
+        "abbr": "min",
+        "full": "minute | minutes"
+      },
+      "second": {
+        "abbr": "s",
+        "full": "seconde | secondes"
+      }
+    },
     "footer": {
       "sitemapAndInformation": "Plan du site & informations",
       "copyright": "© Orange 2026",

--- a/i18n/lang/fr.json
+++ b/i18n/lang/fr.json
@@ -342,10 +342,10 @@
     "errorFirstName": "Le prénom est obligatoire",
     "errorPassword": "Le mot de passe doit être entre 4 et 8 caractères",
     "errorAge": "L'âge doit être un nombre inférieur à 18",
-    "errorEmail": "Le format de l'email n'est pas valide. Exemple de format nom.prenomAROBASEorange.com",
+    "errorEmail": "Le format de l'email n'est pas valide. Exemple de format nom.prenom{'@'}orange.com",
     "errorPhoneNumber": "Le format du téléphone n'est pas valide. Exemple de format +33612345678",
     "errorFruits": "Seuls 3 fruits doivent être sélectionnés !!!",
-    "detailEmail": "(format : nom.prenomAROBASEdomain.com)",
+    "detailEmail": "(format : nom.prenom{'@'}domain.com)",
     "detailPhoneNumber": "(format : +33 suivi de 9 chiffres)",
     "detailFruits": "(3 fruits)"
   },


### PR DESCRIPTION
The lang.json files contained email examples using AROBASE as a workaround, which displayed as-is on the screen.

Correction: Replaced with the official vue-i18n escape syntax.

Two pages were reading the possibleResponses arrays in a fragile manner:

hearing.vue: Detected the end of the array by comparing the returned response to the key itself (a hack).
hearing-simulation.vue: Manually traversed messages.value, bypassing vue-i18n, ignored the fallbackLocale, and contained a console.log left in production.
Correction: Used te() (translation exists), a native vue-i18n function that respects language fallback.

